### PR TITLE
add #00E69E color to theme

### DIFF
--- a/design/atoms/theme/foundations/colors/index.js
+++ b/design/atoms/theme/foundations/colors/index.js
@@ -1,0 +1,47 @@
+"use strict";
+exports.__esModule = true;
+var colors = {
+    'black': {
+        '100': '#606060',
+        '200': '#484848',
+        '300': '#393939',
+        '400': '#2C2C2C',
+        '500': '#212121',
+        '600': '#1B1A1A',
+        '600-faded': 'rgba(27, 26, 26, 0.8)',
+        '700': '#161616',
+        '800': '#0D0C0C'
+    },
+    'chocolate': {
+        '400': '#272520',
+        '500': '#36342f'
+    },
+    'drab': {
+        '500': '#746338'
+    },
+    gold: {
+        '300': '#FFD26A',
+        '500': '#FABD2E',
+        '600': '#AF8420'
+    },
+    gradients: {
+        'background': 'linear-gradient(180deg, #272520 0%, #1B1A18 100%)',
+        'cards': 'linear-gradient(180deg, #403824 0%, #272520 100%)',
+        'glow': 'linear-gradient(180deg, #FABD2E 0%, #FFD36E 100%)'
+    },
+    neutral: {
+        'light-gray': "#F5F5F5",
+        'medium-gray': "#B6B3AC"
+    },
+    'sand': {
+        '500': '#FFDA85',
+        '600': '#E5BE63'
+    },
+    'utility': {
+        'error-red': '#FF7373'
+    },
+    'call-to-action': {
+        'cta-teal': '#00E69E'
+    }
+};
+exports["default"] = colors;

--- a/design/atoms/theme/foundations/colors/index.ts
+++ b/design/atoms/theme/foundations/colors/index.ts
@@ -37,6 +37,9 @@ const colors = {
   },
   'utility': {
     'error-red': '#FF7373'
+  },
+  'call-to-action': {
+    'cta-teal': '#00E69E'
   }
 }
 


### PR DESCRIPTION
## Overview 
It seemed like the color palette lacks some sort of call-to-action hue, so a faded, greenish tint was added.

## Changes
* inside ``` design\atoms\theme\foundations\colors\index.ts ``` , added color category ``` 'call-to-action' ```, then added property ``` 'cta-teal': '#00E69E' ``` to it
## Screenshots

![decent-ui](https://user-images.githubusercontent.com/77731047/177738877-d9f057a1-f617-4bae-9030-7f3fa8f4c87b.png)

## Notes

## Checklist
- [ ]  Ran all tests and manually tested for bugs
- [ ]  Has tested that app successfully builds/starts locally
- [ ]  Has tested that PR deployment (on develop) has been successful
- [ ]  Call out (review comment) and explain new code changes that may not be self-explainatory (when in doubt, leave a comment)
- [ ]  Call out (review comment) any incomplete code, or code that was added as a shim to complete the PR.
- [ ]  Call out (review comment) code that is hacky or will need to be refactored later.
