### PR TITLE
creates figma token color parser

### DIFF
--- a/design/helpers.ts
+++ b/design/helpers.ts
@@ -6,26 +6,33 @@ export function parseColors(colorFigmaTokens: any) {
     const colorObj = Object.entries(tokens!).reduce((prev, cur) => {
 
       // spilts token color and number value gold-500
-      const [, potentialNumber] = cur[0].split("-")
+      const [colorName, potentialNumber] = cur[0].split("-")
 
       // spilt fails its assumed that this is a base color, ie white: {value: #FFF}
-      if(!potentialNumber) {
-        return {...prev, base: cur[1].value}
+      if (!potentialNumber) {
+        // this spilt checks for selectors (active, disabled, hover, etc)
+        const [baseName, selector] = cur[0].split(':')
+
+        // if selector exists create key using number and selector (white-active)
+        if (selector) {
+          return { ...prev, [`${baseName.toLowerCase().trim()}-${selector.trim()}`]: cur[1].value }
+        }
+        return { ...prev, [colorName.toLowerCase()]: cur[1].value }
       }
 
       // this spilt checks for selectors (active, disabled, hover, etc)
       const [colorNumber, selector] = potentialNumber.split(':')
 
       // if selector exists create key using number and selector (500-active)
-      if(selector) {
-        return {...prev, [`${colorNumber}-${selector.trim()}`]: cur[1].value}
+      if (selector) {
+        return { ...prev, [`${colorNumber}-${selector.trim()}`]: cur[1].value }
       }
 
       // returns previous object combined with new color key and value
-      return {...prev, [colorNumber]: cur[1].value}
-    }, {}) 
-    return {[colorCatogoryNames[index].toLowerCase()]: colorObj}
+      return { ...prev, [colorNumber]: cur[1].value }
+    }, {})
+    return { [colorCatogoryNames[index].toLowerCase()]: colorObj }
   }).reduce((prev, cur) => {
-    return {...prev, ...cur}
+    return { ...prev, ...cur }
   }, {})
 }

--- a/design/helpers.ts
+++ b/design/helpers.ts
@@ -1,0 +1,31 @@
+export function parseColors(colorFigmaTokens: any) {
+  // captures color catagory names to create object key
+  const colorCatogoryNames = Object.keys(colorFigmaTokens);
+
+  return Object.values(colorFigmaTokens).flatMap((tokens, index) => {
+    const colorObj = Object.entries(tokens!).reduce((prev, cur) => {
+
+      // spilts token color and number value gold-500
+      const [, potentialNumber] = cur[0].split("-")
+
+      // spilt fails its assumed that this is a base color, ie white: {value: #FFF}
+      if(!potentialNumber) {
+        return {...prev, base: cur[1].value}
+      }
+
+      // this spilt checks for selectors (active, disabled, hover, etc)
+      const [colorNumber, selector] = potentialNumber.split(':')
+
+      // if selector exists create key using number and selector (500-active)
+      if(selector) {
+        return {...prev, [`${colorNumber}-${selector.trim()}`]: cur[1].value}
+      }
+
+      // returns previous object combined with new color key and value
+      return {...prev, [colorNumber]: cur[1].value}
+    }, {}) 
+    return {[colorCatogoryNames[index].toLowerCase()]: colorObj}
+  }).reduce((prev, cur) => {
+    return {...prev, ...cur}
+  }, {})
+}

--- a/design/tokens/foundations/colors/index.ts
+++ b/design/tokens/foundations/colors/index.ts
@@ -1,12 +1,13 @@
+import { parseColors } from '../../../helpers';
 import tokenData from '../../color-tokens.json'
 
 const { Colors } = tokenData;
 const { Primary, Secondary, Neutral, Utility } = Colors;
 
-const primaries = { ...Primary }
-const secondaries = { ...Secondary }
-const neutrals = { ...Neutral }
-const utilities = { ...Utility }
+const primaries = parseColors({...Primary})
+const secondaries = parseColors({ ...Secondary })
+const neutrals = parseColors({ ...Neutral })
+const utilities = parseColors({ ...Utility })
 
 const colors = {
     ...primaries,

--- a/design/tokens/foundations/index.ts
+++ b/design/tokens/foundations/index.ts
@@ -1,8 +1,6 @@
 import colors from './colors'
 import textStyles from './textStyles'
 
-console.log("TEXT STYLES: ", textStyles)
-
 export default {
     colors,
     textStyles

--- a/design/tokens/stories/components/DisplayColors.tsx
+++ b/design/tokens/stories/components/DisplayColors.tsx
@@ -1,58 +1,49 @@
-import { Heading, Box, Text } from '@chakra-ui/react';
-import { StoryLayout } from '../../../shared/StoryLayout';
-import colors from '../../foundations/colors';
+import { Box, Text } from "@chakra-ui/react"
+import { StoryLayout } from "../../../shared/StoryLayout"
+import colors from "../../foundations/colors"
 
 export function DisplayColors() {
-    return (
-        <StoryLayout title='Colors'>
-            {Object.entries(colors).map(([colorCategory, values], index) => {
-                return (
-                    <Box key={colorCategory + index}>
-                        <Heading as='h2' mb={4} fontSize='32px' textTransform={'capitalize'} fontWeight={'bold'}>
-                            {colorCategory}
-                        </Heading>
-                        {Object.entries(values as Object).map(
-                            ([colorTitle, hexValue]) => {
-                                return (
-                                    <Box
-                                        key={colorTitle}
-                                        display='flex'
-                                        justifyContent='space-between'
-                                        flexGrow={1}
-                                        height='75px'
-                                        marginY='12'
-                                    >
-                                        <Box
-                                            width='fit-content'
-                                            display='flex'
-                                            flexDirection='column'
-                                            justifyContent='center'
-                                        >
-                                            <Text
-                                                fontSize='lg'
-                                                marginBottom='4'
-                                                textStyle='text-sm-mono'
-                                            >
-                                                {colorTitle}
-                                            </Text>
-                                            <Text textStyle='text-sm-sans'>
-                                                {hexValue.value}
-                                            </Text>
-                                        </Box>
-                                        <Box
-                                            marginLeft='24'
-                                            flexGrow={1}
-                                            bg={hexValue.value}
-                                            maxWidth='60%'
-                                            borderRadius='lg'
-                                        />
-                                    </Box>
-                                );
-                            }
-                        )}
-                    </Box>
-                );
+  return (
+    <StoryLayout title="Colors">
+      {Object.entries(colors).map(([colorCategory, values], index) => {
+        return (
+          <Box key={colorCategory + index}>
+            {Object.entries(values as Object).map(([colorTitle, value]) => {
+              const colorName = `${colorCategory}-${colorTitle}`
+              const colorKey = `${colorCategory}.${colorTitle}`
+              return (
+                <Box
+                  key={colorName}
+                  display="flex"
+                  justifyContent="space-between"
+                  flexGrow={1}
+                  height="75px"
+                  marginY="12"
+                >
+                  <Box
+                    width="fit-content"
+                    display="flex"
+                    flexDirection="column"
+                    justifyContent="center"
+                  >
+                    <Text fontSize="lg" marginBottom="4" textStyle="text-sm-mono">
+                      {colorName}
+                    </Text>
+                    <Text textStyle="text-sm-sans">{value}</Text>
+                  </Box>
+                  <Box
+                    marginLeft="24"
+                    flexGrow={1}
+                    bg={colorKey}
+                    maxWidth="60%"
+                    borderRadius="lg"
+                  />
+                </Box>
+              )
             })}
-        </StoryLayout>
-    );
+          </Box>
+        )
+      })}
+    </StoryLayout>
+  )
 }


### PR DESCRIPTION
## Overview 
After running the new figma tokens locally I realized that Chakra wasn't picking up the color foundations correctly so that using the key `gold.500` no longer works

I created a color parser helper function to take the figma token object and break it down into objects that Chakra-UI is able to use for our custom theme.

## Changes
- Created a helper method to parse the color figma tokens
- reverted changes to the `ColorsDisplay` component since the foundations object is now back to how it used to be

## Screenshots
n/a

## Notes
n/a

## Checklist
- [x]  Ran all tests and manually tested for bugs
- [x]  Has tested that app successfully builds/starts locally
- [x]  Has tested that PR deployment (on develop) has been successful
- [x]  Call out (review comment) and explain new code changes that may not be self-explainatory (when in doubt, leave a comment)
- [x]  Call out (review comment) any incomplete code, or code that was added as a shim to complete the PR.
- [x]  Call out (review comment) code that is hacky or will need to be refactored later.
