### PR TITLE
UI qa fixes

### DIFF
--- a/design/atoms/components/icons/src/StarGoldSolid.tsx
+++ b/design/atoms/components/icons/src/StarGoldSolid.tsx
@@ -8,7 +8,7 @@ export const StarGoldSolid: ComponentWithAs<"svg", IconProps> = createIcon({
       fillRule="evenodd"
       clipRule="evenodd"
       d="m5.026 20.774 1.49-6.452-4.214-4.106a1 1 0 0 1 .619-1.713l5.701-.453 2.467-5.461a.999.999 0 0 1 1.822 0l2.467 5.46 5.701.455a1 1 0 0 1 .59 1.74l-4.536 4.082 1.829 6.4a1 1 0 0 1-1.517 1.105L12 18.201l-5.445 3.63a.998.998 0 0 1-1.529-1.056Z"
-      fill="#FABD2E"
+      fill="currentColor"
     />
   ),
 })

--- a/design/tokens/components/input/theme/input.base.ts
+++ b/design/tokens/components/input/theme/input.base.ts
@@ -32,6 +32,14 @@ const baseStyle = definePartsStyle({
     _placeholder: {
       color: 'grayscale.600',
     },
+    _active: {
+      border: '1px solid',
+      borderColor: 'black.300',
+      _disabled: {
+        ...disabled,
+        _loading: loading
+      },
+    },
     _hover: {
       border: '1px solid',
       borderColor: 'black.300',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decent-org/fractal-ui",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@decent-org/fractal-ui",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.21.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decent-org/fractal-ui",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Decent DAO design system component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Overview 
This PR adds missing `_active` styling for the input and removes hard-coded gold star color

## Changes
- Add missing `_active` pseudo-class for the input
- Set `fill="currentColor"` on `StarGoldSolid` icon

## Screenshots
N/A

## Notes
Comes in scope of https://github.com/decent-dao/fractal-interface/issues/1169

## Checklist
- [ ]  Ran all tests and manually tested for bugs
- [ ]  Has tested that app successfully builds/starts locally
- [ ]  Has tested that PR deployment (on develop) has been successful
- [ ]  Call out (review comment) and explain new code changes that may not be self-explainatory (when in doubt, leave a comment)
- [ ]  Call out (review comment) any incomplete code, or code that was added as a shim to complete the PR.
- [ ]  Call out (review comment) code that is hacky or will need to be refactored later.
